### PR TITLE
Add support for zones with a dot at the end

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/libdns/timeweb
 
 go 1.18
 
-require github.com/libdns/libdns v0.2.2
+require (
+	github.com/joho/godotenv v1.5.1
+	github.com/libdns/libdns v0.2.3
+	github.com/stretchr/testify v1.10.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
 github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,10 @@
 package timeweb
 
-import "github.com/libdns/libdns"
+import (
+	"strings"
+
+	"github.com/libdns/libdns"
+)
 
 func isRecordExists(records []libdns.Record, libRecord libdns.Record) bool {
 	for _, record := range records {
@@ -13,8 +17,5 @@ func isRecordExists(records []libdns.Record, libRecord libdns.Record) bool {
 }
 
 func normalizeZone(zone string) string {
-	if len(zone) > 0 && zone[len(zone)-1] == '.' {
-		return zone[:len(zone)-1]
-	}
-	return zone
+	return strings.TrimSuffix(strings.Replace(zone, "*.", "", 1), ".")
 }

--- a/helpers.go
+++ b/helpers.go
@@ -11,3 +11,10 @@ func isRecordExists(records []libdns.Record, libRecord libdns.Record) bool {
 
 	return false
 }
+
+func normalizeZone(zone string) string {
+	if len(zone) > 0 && zone[len(zone)-1] == '.' {
+		return zone[:len(zone)-1]
+	}
+	return zone
+}

--- a/provider.go
+++ b/provider.go
@@ -3,8 +3,9 @@ package timeweb
 import (
 	"context"
 	"fmt"
-	"github.com/libdns/libdns"
 	"net/http"
+
+	"github.com/libdns/libdns"
 )
 
 type Provider struct {
@@ -13,6 +14,7 @@ type Provider struct {
 }
 
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
+	zone = normalizeZone(zone)
 	reqURL := fmt.Sprintf("%s/domains/%s/dns-records", p.ApiURL, zone)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -31,6 +33,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 }
 
 func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	zone = normalizeZone(zone)
 	var created []libdns.Record
 	for _, record := range records {
 		result, err := p.createRecord(ctx, zone, record)
@@ -44,6 +47,7 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 }
 
 func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	zone = normalizeZone(zone)
 	var deleted []libdns.Record
 	for _, record := range records {
 		err := p.deleteRecord(ctx, zone, record)
@@ -57,6 +61,7 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 }
 
 func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	zone = normalizeZone(zone)
 	zoneRecords, err := p.GetRecords(ctx, zone)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When trying to access the API with a zone ending in a dot, Timeweb returns a response with the 404 code and the `"Not found"` message.
A function has been added to normalize the zone in the file `helpers.go`.