### PR TITLE
Update for libdns v1.1.0 API compatibility

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,8 +23,37 @@ func (p *Provider) createRecord(ctx context.Context, zone string, record libdns.
 
 func (p *Provider) updateRecord(ctx context.Context, zone string, record libdns.Record) (SavedRecord, error) {
 	body, err := json.Marshal(libdnsToRecord(record))
-	reqURL := fmt.Sprintf("%s/domains/%s/dns-records/%s", p.ApiURL, zone, record.ID)
+	if err != nil {
+		return SavedRecord{}, err
+	}
+
+	recordID := getRecordID(record)
+	if recordID == "" {
+		// Need to look up the record by name/type to get the ID
+		existingRecords, err := p.GetRecords(ctx, zone)
+		if err != nil {
+			return SavedRecord{}, fmt.Errorf("failed to get records for update: %w", err)
+		}
+
+		targetRR := record.RR()
+		for _, existing := range existingRecords {
+			existingRR := existing.RR()
+			if existingRR.Name == targetRR.Name && existingRR.Type == targetRR.Type {
+				recordID = getRecordID(existing)
+				break
+			}
+		}
+
+		if recordID == "" {
+			return SavedRecord{}, fmt.Errorf("record not found for update: %s %s", targetRR.Name, targetRR.Type)
+		}
+	}
+
+	reqURL := fmt.Sprintf("%s/domains/%s/dns-records/%s", p.ApiURL, zone, recordID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return SavedRecord{}, err
+	}
 
 	var result SavedRecord
 	err = p.doAPIRequest(req, &result)
@@ -33,8 +62,34 @@ func (p *Provider) updateRecord(ctx context.Context, zone string, record libdns.
 }
 
 func (p *Provider) deleteRecord(ctx context.Context, zone string, record libdns.Record) error {
-	reqURL := fmt.Sprintf("%s/domains/%s/dns-records/%s", p.ApiURL, zone, record.ID)
+	recordID := getRecordID(record)
+	if recordID == "" {
+		// Need to look up the record by name/type to get the ID
+		existingRecords, err := p.GetRecords(ctx, zone)
+		if err != nil {
+			return fmt.Errorf("failed to get records for delete: %w", err)
+		}
+
+		targetRR := record.RR()
+		for _, existing := range existingRecords {
+			existingRR := existing.RR()
+			if existingRR.Name == targetRR.Name && existingRR.Type == targetRR.Type && existingRR.Data == targetRR.Data {
+				recordID = getRecordID(existing)
+				break
+			}
+		}
+
+		if recordID == "" {
+			// Record doesn't exist, which is fine for delete
+			return nil
+		}
+	}
+
+	reqURL := fmt.Sprintf("%s/domains/%s/dns-records/%s", p.ApiURL, zone, recordID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return err
+	}
 
 	err = p.doAPIRequest(req, nil)
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/libdns/timeweb
 
-go 1.18
+go 1.21
 
 require (
 	github.com/joho/godotenv v1.5.1
-	github.com/libdns/libdns v0.2.3
+	github.com/libdns/libdns v1.1.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
-github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.1.0 h1:9ze/tWvt7Df6sbhOJRB8jT33GHEHpEQXdtkE3hPthbU=
+github.com/libdns/libdns v1.1.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/helpers.go
+++ b/helpers.go
@@ -7,8 +7,10 @@ import (
 )
 
 func isRecordExists(records []libdns.Record, libRecord libdns.Record) bool {
+	targetRR := libRecord.RR()
 	for _, record := range records {
-		if libRecord.ID == record.ID || (libRecord.Name == record.Name && libRecord.Type == record.Type) {
+		rr := record.RR()
+		if targetRR.Name == rr.Name && targetRR.Type == rr.Type {
 			return true
 		}
 	}

--- a/models.go
+++ b/models.go
@@ -41,28 +41,138 @@ type SavedRecord struct {
 }
 
 func (r *SavedRecord) libDNSRecord(zone string) libdns.Record {
-	return libdns.Record{
-		ID:    fmt.Sprintf("%d", r.DNSRecord.ID),
-		Name:  libdns.RelativeName(r.DNSRecord.Data.Subdomain, zone),
-		Type:  r.DNSRecord.Type,
-		Value: r.DNSRecord.Data.Value,
+	name := libdns.RelativeName(r.DNSRecord.Data.Subdomain, zone)
+	recordType := r.DNSRecord.Type
+	value := r.DNSRecord.Data.Value
+	recordID := r.DNSRecord.ID
+
+	// Return typed records based on record type
+	switch recordType {
+	case "TXT":
+		return libdns.TXT{
+			Name:         name,
+			Text:         value,
+			ProviderData: recordID, // Store Timeweb ID for updates/deletes
+		}
+	case "A", "AAAA":
+		// For A/AAAA records, we need to parse the IP address
+		rr := libdns.RR{
+			Name: name,
+			Type: recordType,
+			Data: value,
+		}
+		parsed, err := rr.Parse()
+		if err == nil {
+			// Attach provider data to the parsed record
+			if addr, ok := parsed.(libdns.Address); ok {
+				addr.ProviderData = recordID
+				return addr
+			}
+		}
+		return rr
+	case "CNAME":
+		return libdns.CNAME{
+			Name:         name,
+			Target:       value,
+			ProviderData: recordID,
+		}
+	case "MX":
+		return libdns.MX{
+			Name:         name,
+			Target:       value,
+			ProviderData: recordID,
+		}
+	default:
+		// For unknown types, return RR
+		return libdns.RR{
+			Name: name,
+			Type: recordType,
+			Data: value,
+		}
 	}
 }
 
 func (r *RecordResponse) libDNSRecord(zone string) libdns.Record {
-	return libdns.Record{
-		ID:       fmt.Sprintf("%d", r.ID),
-		Name:     libdns.RelativeName(r.Fqdn, zone),
-		Type:     r.Type,
-		Value:    r.Data.Value,
-		Priority: r.Data.Priority,
+	name := libdns.RelativeName(r.Fqdn, zone)
+	recordType := r.Type
+	value := r.Data.Value
+	recordID := r.ID
+
+	// Return typed records based on record type
+	switch recordType {
+	case "TXT":
+		return libdns.TXT{
+			Name:         name,
+			Text:         value,
+			ProviderData: recordID, // Store Timeweb ID for updates/deletes
+		}
+	case "A", "AAAA":
+		// For A/AAAA records, we need to parse the IP address
+		rr := libdns.RR{
+			Name: name,
+			Type: recordType,
+			Data: value,
+		}
+		parsed, err := rr.Parse()
+		if err == nil {
+			// Attach provider data to the parsed record
+			if addr, ok := parsed.(libdns.Address); ok {
+				addr.ProviderData = recordID
+				return addr
+			}
+		}
+		return rr
+	case "CNAME":
+		return libdns.CNAME{
+			Name:         name,
+			Target:       value,
+			ProviderData: recordID,
+		}
+	case "MX":
+		return libdns.MX{
+			Name:         name,
+			Preference:   uint16(r.Data.Priority),
+			Target:       value,
+			ProviderData: recordID,
+		}
+	default:
+		// For unknown types, return RR
+		return libdns.RR{
+			Name: name,
+			Type: recordType,
+			Data: value,
+		}
 	}
 }
 
 func libdnsToRecord(r libdns.Record) Record {
+	rr := r.RR()
 	return Record{
-		Type:      r.Type,
-		Value:     r.Value,
-		Subdomain: r.Name,
+		Type:      rr.Type,
+		Value:     rr.Data,
+		Subdomain: rr.Name,
 	}
+}
+
+// getRecordID extracts the Timeweb record ID from ProviderData or returns empty string
+func getRecordID(r libdns.Record) string {
+	switch rec := r.(type) {
+	case libdns.TXT:
+		if id, ok := rec.ProviderData.(uint); ok {
+			return fmt.Sprintf("%d", id)
+		}
+	case libdns.Address:
+		if id, ok := rec.ProviderData.(uint); ok {
+			return fmt.Sprintf("%d", id)
+		}
+	case libdns.CNAME:
+		if id, ok := rec.ProviderData.(uint); ok {
+			return fmt.Sprintf("%d", id)
+		}
+	case libdns.MX:
+		if id, ok := rec.ProviderData.(uint); ok {
+			return fmt.Sprintf("%d", id)
+		}
+	}
+	return ""
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -2,6 +2,8 @@ package timeweb_test
 
 import (
 	"context"
+	"net/netip"
+
 	"github.com/joho/godotenv"
 	"github.com/libdns/libdns"
 	"github.com/libdns/timeweb"
@@ -29,10 +31,9 @@ func setup() {
 	zone = os.Getenv("TIMEWEB_ZONE")
 	ctx = context.Background()
 	sourceRecords = []libdns.Record{
-		{
-			Type:  "A",
-			Name:  zone,
-			Value: "1.2.3.1",
+		libdns.Address{
+			Name: zone,
+			IP:   netip.MustParseAddr("1.2.3.1"),
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Updates the Timeweb DNS provider to be compatible with libdns v1.1.0, which introduced breaking changes to the `Record` type (changed from struct to interface).

## Changes

- Update `github.com/libdns/libdns` from v0.2.3 to v1.1.0
- Refactor `libDNSRecord()` methods to return typed records (`libdns.TXT`, `libdns.Address`, `libdns.CNAME`, `libdns.MX`) instead of struct literals
- Use `ProviderData` field to store Timeweb record IDs for update/delete operations
- Update all record field access to use `record.RR()` method (new interface-based API)
- Add fallback lookup logic when record ID is not available in ProviderData
- Update tests for new Record interface API
- Bump Go version to 1.21

## Breaking Changes

None for consumers - the libdns interfaces remain the same, only internal implementation updated.

## Testing

- Module compiles without errors
- Tests updated to use new typed record API
- Successfully tested with Caddy v2.10.2

## Compatibility

This update makes the provider compatible with:
- Caddy v2.10.x and later
- Any other software using libdns v1.1.0+